### PR TITLE
Add function to float preferred full-text targets to the top of full-tex...

### DIFF
--- a/app/service_adaptors/sfx.rb
+++ b/app/service_adaptors/sfx.rb
@@ -232,6 +232,7 @@ class Sfx < Service
 
       # For each target delivered by SFX
       sfx_obj.search("./ctx_obj_targets/target").each_with_index do|target, target_index|
+        
         response_data = {}
 
         # First check @extra_targets_of_interest
@@ -377,7 +378,9 @@ class Sfx < Service
     end
 
     if response_queue["fulltext"].present?
+      #Rails.logger.info(response_queue['fulltext'])
       response_queue["fulltext"] = roll_up_responses(response_queue["fulltext"], :coverage_sensitive => request.title_level_citation? )
+      response_queue["fulltext"] = sort_preferred_responses(response_queue["fulltext"])
     end
 
     # Now that they've been post-processed, actually commit them.
@@ -517,6 +520,14 @@ class Sfx < Service
     return list
   end
 
+  def sort_preferred_responses(list)
+
+    preferred_targets = @preferred_targets
+    non_preferred_targets = list.reject {|a| preferred_targets.include?(a[:sfx_target_name])}
+    available_preferred_targets = list.select {|a| preferred_targets.include?(a[:sfx_target_name])}
+    #list = list.sort {|a,b| a[:sfx_target_name] <=> b[:sfx_target_name]}.reverse 
+    return available_preferred_targets + non_preferred_targets
+  end
 
   def sfx_click_passthrough
     # From config, or default to false.
@@ -726,5 +737,4 @@ class Sfx < Service
     return display
   end
 
-  end
-
+end


### PR DESCRIPTION
...t matches. Fires after target rollup happens. Moves targets from the "preferred_targets" config array to the top of the full-text list. Otherwise the sort of target should be the same. 