### PR TITLE
Support Configuration of Full-Text Target Precedence for SFX

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -48,7 +48,7 @@ properly assigned service wave, and/or executed more than once. This has been fi
 SERVICE-SPECIFIC
 
 * InternetArchive: Require closer title match to count as a hit. 
-* SFX: TODO
+* SFX: Add boost_targets and sink_targets options to reorder targets. 
 * Web of Science and JCR: Optionally support username/password-based auth
 
 ## 4.0

--- a/app/service_adaptors/sfx.rb
+++ b/app/service_adaptors/sfx.rb
@@ -530,31 +530,29 @@ class Sfx < Service
   end
 
   def sort_preferred_responses(list)
-    
-    preferred_targets = @preferred_targets
-    return list unless preferred_targets.present?
+    return list unless @preferred_targets.present?
 
-    other_targets = list.reject {|a| preferred_targets.include?(a[:sfx_target_name])}
-    avail_preferred_targets = list.select {|a| preferred_targets.include?(a[:sfx_target_name])}
-    avail_preferred_targets = avail_preferred_targets.sort do |item1, item2|
-      preferred_targets.index(item1[:sfx_target_name]) <=> preferred_targets.index(item2[:sfx_target_name])
+    preferred = []
+    other_targets = list
+    @preferred_targets.each do |spec|
+      (picked, other_targets) = other_targets.partition {|a| spec == a[:sfx_target_name] }
+      preferred.concat picked
     end
-    
-    return avail_preferred_targets + other_targets
+            
+    return preferred + other_targets
   end
 
   def sort_sunk_responses(list)
+    return list unless @sunk_targets.present?
     
-    sunk_targets = @sunk_targets
-    return list unless sunk_targets.present?
-
-    better_targets = list.reject {|a| sunk_targets.include?(a[:sfx_target_name])}
-    available_sunk_targets = list.select {|a| sunk_targets.include?(a[:sfx_target_name])}
-    available_sunk_targets = available_sunk_targets.sort do |item1, item2|
-      sunk_targets.index(item1[:sfx_target_name]) <=> sunk_targets.index(item2[:sfx_target_name])
+    sunk = []
+    other_targets = list
+    @sunk_targets.each do |spec|
+      (picked, other_targets) = other_targets.partition {|a| spec == a[:sfx_target_name] }
+      sunk.concat picked
     end
-
-    return better_targets + available_sunk_targets
+            
+    return other_targets + sunk
   end
 
   def sfx_click_passthrough

--- a/app/service_adaptors/sfx.rb
+++ b/app/service_adaptors/sfx.rb
@@ -42,9 +42,9 @@
 #      in response. For TITLE-LEVEL (rather than article-level) requests,
 #      the roll-up algorithm is sensitive to COVERAGES, and will only suppress
 #      targets that have coverages included in remaining non-suppressed targets.
-# preferred_targets: ARRAY of STRINGS containing SFX target names in the form of
+# boosted_targets: ARRAY of STRINGS containing SFX target names in the form of
 #      "HIGHWIRE_PRESS_JOURNALS". Any target names listed here will be floated to 
-#      the top of the full-text results list. You can end your preferred target
+#      the top of the full-text results list. You can end your boosted target
 #      in a "*" to wildcard: "EBSCOHOST_*". Multiple matching targets will be displayed
 #      in alpha order. This fires AFTER 'roll_up_prefixes'  
 # sunk_targets: ARRAY of STRINGS containing SFX target names in the form of
@@ -390,7 +390,7 @@ class Sfx < Service
 
     if response_queue["fulltext"].present?
       response_queue["fulltext"] = roll_up_responses(response_queue["fulltext"], :coverage_sensitive => request.title_level_citation? )
-      response_queue["fulltext"] = sort_preferred_responses(response_queue["fulltext"])
+      response_queue["fulltext"] = sort_boosted_responses(response_queue["fulltext"])
       response_queue["fulltext"] = sort_sunk_responses(response_queue["fulltext"])
     end
 
@@ -531,13 +531,13 @@ class Sfx < Service
     return list
   end
 
-  def sort_preferred_responses(list)
-    return list unless @preferred_targets.present?
+  def sort_boosted_responses(list)
+    return list unless @boosted_targets.present?
 
     preferred = []
     other_targets = list
 
-    @preferred_targets.each do |spec|
+    @boosted_targets.each do |spec|
       (picked, other_targets) = other_targets.partition do |a| 
         if spec.end_with?("*")
           a[:sfx_target_name].start_with? spec[0..-2]

--- a/app/service_adaptors/sfx.rb
+++ b/app/service_adaptors/sfx.rb
@@ -390,8 +390,8 @@ class Sfx < Service
 
     if response_queue["fulltext"].present?
       response_queue["fulltext"] = roll_up_responses(response_queue["fulltext"], :coverage_sensitive => request.title_level_citation? )
-      response_queue["fulltext"] = sort_boosted_responses(response_queue["fulltext"])
       response_queue["fulltext"] = sort_sunk_responses(response_queue["fulltext"])
+      response_queue["fulltext"] = sort_boosted_responses(response_queue["fulltext"])
     end
 
     # Now that they've been post-processed, actually commit them.
@@ -540,7 +540,7 @@ class Sfx < Service
     @boosted_targets.each do |spec|
       (picked, other_targets) = other_targets.partition do |a| 
         if spec.end_with?("*")
-          a[:sfx_target_name].start_with? spec[0..-2]
+          a[:sfx_target_name] && a[:sfx_target_name].start_with?(spec[0..-2])
         else
           spec == a[:sfx_target_name] 
         end
@@ -560,7 +560,7 @@ class Sfx < Service
     @sunk_targets.each do |spec|
       (picked, other_targets) = other_targets.partition do |a| 
         if spec.end_with?("*")
-          a[:sfx_target_name].start_with? spec[0..-2]
+          a[:sfx_target_name] && a[:sfx_target_name].start_with?(spec[0..-2])
         else
           spec == a[:sfx_target_name] 
         end

--- a/app/service_adaptors/sfx.rb
+++ b/app/service_adaptors/sfx.rb
@@ -42,8 +42,6 @@
 #      in response. For TITLE-LEVEL (rather than article-level) requests,
 #      the roll-up algorithm is sensitive to COVERAGES, and will only suppress
 #      targets that have coverages included in remaining non-suppressed targets.
-# related_title_label: The label prefixed in front of the message denoting a full
-#      related title.
 # preferred_targets: ARRAY of STRINGS containing SFX target names in the form of
 #      "HIGHWIRE_PRESS_JOURNALS". Any target names listed here will be floated to 
 #      the top of the full-text results list. Multiple matching targets will be displayed

--- a/app/service_adaptors/sfx.rb
+++ b/app/service_adaptors/sfx.rb
@@ -36,22 +36,20 @@
 #     relationships, set to empty array [] to eliminate defaults.
 # sfx_timeout: in seconds, for both open/read timeout value for SFX connection.
 #          Defaults to 8.
+# boost_targets: ARRAY of STRINGS containing SFX target names in the form of
+#      "HIGHWIRE_PRESS_JOURNALS". Any target names listed here will be floated to 
+#      the top of the full-text results list. You can end your boosted target
+#      in a "*" to wildcard: "EBSCOHOST_*". 
+# sink_targets: ARRAY of STRINGS containing SFX target names in the form of
+#      "HIGHWIRE_PRESS_JOURNALS". Any target names listed here will be floated to 
+#      the bottom of the full-text results list. You an end your sunk target
+#      in a "*" to wildcard: "EBSCOHOST_*". 
 # roll_up_prefixes: ARRAY of STRINGs, prefixes like "EBSCOHOST_". If multiple
 #      targets sharing one of the specified prefixes are supplied from SFX,
 #      they will be "rolled up" and collapsed, just the first one included
 #      in response. For TITLE-LEVEL (rather than article-level) requests,
 #      the roll-up algorithm is sensitive to COVERAGES, and will only suppress
 #      targets that have coverages included in remaining non-suppressed targets.
-# boosted_targets: ARRAY of STRINGS containing SFX target names in the form of
-#      "HIGHWIRE_PRESS_JOURNALS". Any target names listed here will be floated to 
-#      the top of the full-text results list. You can end your boosted target
-#      in a "*" to wildcard: "EBSCOHOST_*". Multiple matching targets will be displayed
-#      in alpha order. This fires AFTER 'roll_up_prefixes'  
-# sunk_targets: ARRAY of STRINGS containing SFX target names in the form of
-#      "HIGHWIRE_PRESS_JOURNALS". Any target names listed here will be floated to 
-#      the bottom of the full-text results list. You an end your sunk target
-#      in a "*" to wildcard: "EBSCOHOST_*". Multiple matching targets will be displayed
-#      in alpha order. This fires AFTER 'roll_up_prefixes'
 #      
 class Sfx < Service
   require 'uri'
@@ -389,9 +387,9 @@ class Sfx < Service
     end
 
     if response_queue["fulltext"].present?
-      response_queue["fulltext"] = roll_up_responses(response_queue["fulltext"], :coverage_sensitive => request.title_level_citation? )
       response_queue["fulltext"] = sort_sunk_responses(response_queue["fulltext"])
       response_queue["fulltext"] = sort_boosted_responses(response_queue["fulltext"])
+      response_queue["fulltext"] = roll_up_responses(response_queue["fulltext"], :coverage_sensitive => request.title_level_citation? )
     end
 
     # Now that they've been post-processed, actually commit them.
@@ -532,12 +530,12 @@ class Sfx < Service
   end
 
   def sort_boosted_responses(list)
-    return list unless @boosted_targets.present?
+    return list unless @boost_targets.present?
 
     preferred = []
     other_targets = list
 
-    @boosted_targets.each do |spec|
+    @boost_targets.each do |spec|
       (picked, other_targets) = other_targets.partition do |a| 
         if spec.end_with?("*")
           a[:sfx_target_name] && a[:sfx_target_name].start_with?(spec[0..-2])
@@ -553,11 +551,11 @@ class Sfx < Service
   end
 
   def sort_sunk_responses(list)
-    return list unless @sunk_targets.present?
+    return list unless @sink_targets.present?
     
     sunk = []
     other_targets = list
-    @sunk_targets.each do |spec|
+    @sink_targets.each do |spec|
       (picked, other_targets) = other_targets.partition do |a| 
         if spec.end_with?("*")
           a[:sfx_target_name] && a[:sfx_target_name].start_with?(spec[0..-2])

--- a/app/service_adaptors/sfx.rb
+++ b/app/service_adaptors/sfx.rb
@@ -44,11 +44,13 @@
 #      targets that have coverages included in remaining non-suppressed targets.
 # preferred_targets: ARRAY of STRINGS containing SFX target names in the form of
 #      "HIGHWIRE_PRESS_JOURNALS". Any target names listed here will be floated to 
-#      the top of the full-text results list. Multiple matching targets will be displayed
+#      the top of the full-text results list. You can end your preferred target
+#      in a "*" to wildcard: "EBSCOHOST_*". Multiple matching targets will be displayed
 #      in alpha order. This fires AFTER 'roll_up_prefixes'  
 # sunk_targets: ARRAY of STRINGS containing SFX target names in the form of
 #      "HIGHWIRE_PRESS_JOURNALS". Any target names listed here will be floated to 
-#      the bottom of the full-text results list. Multiple matching targets will be displayed
+#      the bottom of the full-text results list. You an end your sunk target
+#      in a "*" to wildcard: "EBSCOHOST_*". Multiple matching targets will be displayed
 #      in alpha order. This fires AFTER 'roll_up_prefixes'
 #      
 class Sfx < Service
@@ -534,8 +536,16 @@ class Sfx < Service
 
     preferred = []
     other_targets = list
+
     @preferred_targets.each do |spec|
-      (picked, other_targets) = other_targets.partition {|a| spec == a[:sfx_target_name] }
+      (picked, other_targets) = other_targets.partition do |a| 
+        if spec.end_with?("*")
+          a[:sfx_target_name].start_with? spec[0..-2]
+        else
+          spec == a[:sfx_target_name] 
+        end
+      end
+
       preferred.concat picked
     end
             
@@ -548,7 +558,13 @@ class Sfx < Service
     sunk = []
     other_targets = list
     @sunk_targets.each do |spec|
-      (picked, other_targets) = other_targets.partition {|a| spec == a[:sfx_target_name] }
+      (picked, other_targets) = other_targets.partition do |a| 
+        if spec.end_with?("*")
+          a[:sfx_target_name].start_with? spec[0..-2]
+        else
+          spec == a[:sfx_target_name] 
+        end
+      end
       sunk.concat picked
     end
             

--- a/test/unit/sfx/sfx_target_precedence_test.rb
+++ b/test/unit/sfx/sfx_target_precedence_test.rb
@@ -10,7 +10,7 @@ class SfxTargetPrecedenceTest < ActiveSupport::TestCase
   def test_boosted_target_appears_first
     sfx = Sfx.new({'priority' => 1, 
                    'base_url' => "http://example.org",
-                   'boosted_targets' => ['HIGHWIRE_PRESS_JOURNALS']
+                   'boost_targets' => ['HIGHWIRE_PRESS_JOURNALS']
     })
     new_list = sfx.sort_boosted_responses(@@svc_list_example)
     assert_not_same @@svc_list_example, new_list
@@ -22,7 +22,7 @@ class SfxTargetPrecedenceTest < ActiveSupport::TestCase
   def test_boosted_wildcard
     sfx = Sfx.new({'priority' => 1, 
                    'base_url' => "http://example.org",
-                   'boosted_targets' => ['GALEGROUP_*']
+                   'boost_targets' => ['GALEGROUP_*']
     })
     new_list = sfx.sort_boosted_responses(@@svc_list_example)
     assert_not_same @@svc_list_example, new_list
@@ -34,7 +34,7 @@ class SfxTargetPrecedenceTest < ActiveSupport::TestCase
   def test_sunk_target_appears_last
     sfx = Sfx.new({'priority' => 1, 
                    'base_url' => "http://example.org",
-                   'sunk_targets' => ['JSTOR_EARLY_JOURNAL_CONTENT_FREE']
+                   'sink_targets' => ['JSTOR_EARLY_JOURNAL_CONTENT_FREE']
     })
     
     new_list = sfx.sort_sunk_responses(@@svc_list_example)
@@ -47,7 +47,7 @@ class SfxTargetPrecedenceTest < ActiveSupport::TestCase
   def test_sunk_wildcard
     sfx = Sfx.new({'priority' => 1, 
                    'base_url' => "http://example.org",
-                   'sunk_targets' => ['PROQUEST_*']
+                   'sink_targets' => ['PROQUEST_*']
     })
     
     new_list = sfx.sort_sunk_responses(@@svc_list_example)
@@ -60,7 +60,7 @@ class SfxTargetPrecedenceTest < ActiveSupport::TestCase
   def test_boosted_targets_appear_in_order
     sfx = Sfx.new({'priority' => 1, 
                    'base_url' => "http://example.org",
-                   'boosted_targets' => ['PROQUEST_CENTRAL_NEW_PLATFORM', 'HIGHWIRE_PRESS_JOURNALS']
+                   'boost_targets' => ['PROQUEST_CENTRAL_NEW_PLATFORM', 'HIGHWIRE_PRESS_JOURNALS']
     })
     new_list = sfx.sort_boosted_responses(@@svc_list_example)
     assert_not_same @@svc_list_example, new_list
@@ -73,7 +73,7 @@ class SfxTargetPrecedenceTest < ActiveSupport::TestCase
   def test_sunk_targets_appear_in_order
     sfx = Sfx.new({'priority' => 1, 
                    'base_url' => "http://example.org",
-                   'sunk_targets' => ['GALEGROUP_GREENR', 'EBSCOHOST_MAS_ULTRA_SCHOOL_EDITION']
+                   'sink_targets' => ['GALEGROUP_GREENR', 'EBSCOHOST_MAS_ULTRA_SCHOOL_EDITION']
     })
     new_list = sfx.sort_sunk_responses(@@svc_list_example)
     assert_not_same @@svc_list_example, new_list

--- a/test/unit/sfx/sfx_target_precedence_test.rb
+++ b/test/unit/sfx/sfx_target_precedence_test.rb
@@ -1,0 +1,122 @@
+require 'test_helper'
+### 
+### Tests adding the followig config values to the SFX service adaptor
+###
+### @preferred_targets - float specific targets to the top of full-text options
+### @sunk_targets - sink specified targets to the bottom of full-text options
+
+class SfxTargetPrecedenceTest < ActiveSupport::TestCase
+
+  def test_preferred_target_appears_first
+    sfx = Sfx.new({'priority' => 1, 
+                   'base_url' => "http://example.org",
+                   'preferred_targets' => ['HIGHWIRE_PRESS_JOURNALS']
+    })
+    new_list = sfx.sort_preferred_responses(@@svc_list_example)
+    assert_not_same @@svc_list_example, new_list
+      
+    assert_equal new_list.first[:sfx_target_name], 'HIGHWIRE_PRESS_JOURNALS'
+  end
+
+  def test_sunk_target_appears_last
+    sfx = Sfx.new({'priority' => 1, 
+                   'base_url' => "http://example.org",
+                   'sunk_targets' => ['JSTOR_EARLY_JOURNAL_CONTENT_FREE']
+    })
+    
+    new_list = sfx.sort_sunk_responses(@@svc_list_example)
+    assert_not_same @@svc_list_example, new_list
+    assert_equal new_list.last[:sfx_target_name], 'JSTOR_EARLY_JOURNAL_CONTENT_FREE'
+  end
+
+  def test_preferred_targets_appear_in_order
+    sfx = Sfx.new({'priority' => 1, 
+                   'base_url' => "http://example.org",
+                   'preferred_targets' => ['PROQUEST_CENTRAL_NEW_PLATFORM', 'HIGHWIRE_PRESS_JOURNALS']
+    })
+    new_list = sfx.sort_preferred_responses(@@svc_list_example)
+    assert_not_same @@svc_list_example, new_list
+    first_target = new_list[0]
+    second_target = new_list[1]
+    assert_equal first_target[:sfx_target_name], 'PROQUEST_CENTRAL_NEW_PLATFORM'
+    assert_equal second_target[:sfx_target_name], 'HIGHWIRE_PRESS_JOURNALS'
+  end
+
+  def test_sunk_targets_appear_in_order
+    sfx = Sfx.new({'priority' => 1, 
+                   'base_url' => "http://example.org",
+                   'sunk_targets' => ['GALEGROUP_GREENR', 'EBSCOHOST_MAS_ULTRA_SCHOOL_EDITION']
+    })
+    new_list = sfx.sort_sunk_responses(@@svc_list_example)
+    assert_not_same @@svc_list_example, new_list
+    first_target = new_list[-2]
+    second_target = new_list.last
+    assert_equal first_target[:sfx_target_name], 'GALEGROUP_GREENR'
+    assert_equal second_target[:sfx_target_name], 'EBSCOHOST_MAS_ULTRA_SCHOOL_EDITION'
+  end
+
+  @@svc_list_example = [
+
+    { :display_text => "JSTOR Early Journal Content",
+      :sfx_target_name => "JSTOR_EARLY_JOURNAL_CONTENT_FREE",
+      :coverage_begin_date => Date.new(1880,1,1),
+      :coverage_end_date => Date.new(1922,12,31)
+    },
+    { :display_text => "JSTOR_LIFE_SCIENCES_COLLECTION",
+      :sfx_target_name => "JSTOR_LIFE_SCIENCES_COLLECTION",
+      :coverage_begin_date => Date.new(1880,1,1),
+      :coverage_end_date => Date.new(2007,12,31)
+    },
+    { :display_text => "EBSCOHOST_ACADEMIC_SEARCH_COMPLETE",
+      :sfx_target_name => "EBSCOHOST_ACADEMIC_SEARCH_COMPLETE",
+      :coverage_begin_date => Date.new(1997,1,1),
+      :coverage_end_date => Date.new(2010,12,31)
+    },
+    { :display_text => "EBSCOHOST_HEALTH_SOURCE_NURSING_ACADEMIC",
+      :sfx_target_name => "EBSCOHOST_HEALTH_SOURCE_NURSING_ACADEMIC",
+      :coverage_begin_date => Date.new(1997,1,1),
+      :coverage_end_date => Date.new(2004,12,31)
+    },
+    { :display_text => "EBSCOHOST_MAS_ULTRA_SCHOOL_EDITION",
+      :sfx_target_name => "EBSCOHOST_MAS_ULTRA_SCHOOL_EDITION",
+      :coverage_begin_date => Date.new(1997,1,1),
+      :coverage_end_date => Date.new(2006,12,31)
+    },
+    { :display_text => "EBSCOHOST_MASTERFILE_PREMIER",
+      :sfx_target_name => "EBSCOHOST_MASTERFILE_PREMIER",
+      :coverage_begin_date => Date.new(1997,1,1),
+      :coverage_end_date => Date.new(2004,12,31)
+    },
+    { :display_text => "HIGHWIRE_PRESS_JOURNALS",
+      :sfx_target_name => "HIGHWIRE_PRESS_JOURNALS",
+      :coverage_begin_date => Date.new(1997,1,1),
+      :coverage_end_date => Date.new(2006,12,31)
+    },
+    { :display_text => "PROQUEST_CENTRAL_NEW_PLATFORM",
+      :sfx_target_name => "PROQUEST_CENTRAL_NEW_PLATFORM",
+      :coverage_begin_date => Date.new(1988,1,1),
+      :coverage_end_date => Date.new(2005,12,31)
+    },
+    { :display_text => "PROQUEST_ENGINEERING_JOURNALS_NEW_PLATFORM",
+      :sfx_target_name => "PROQUEST_ENGINEERING_JOURNALS_NEW_PLATFORM",
+      :coverage_begin_date => Date.new(1980,1,1),
+      :coverage_end_date => Date.new(2000,12,31)
+    },
+    { :display_text => "PROQUEST_MEDLINE_WITH_FULLTEXT",
+      :sfx_target_name => "PROQUEST_MEDLINE_WITH_FULLTEXT",
+      :coverage_begin_date => Date.new(1988,1,1),
+      :coverage_end_date => Date.new(2005,12,31)
+    },
+    { :display_text => "GALEGROUP_GREENR",
+      :sfx_target_name => "GALEGROUP_GREENR",
+      :coverage_begin_date => Date.new(1983,1,1),
+      :coverage_end_date => Date.new(2005,12,31)
+    },
+    { :display_text => "GALEGROUP_BIOGRAPHY_IN_CONTEXT",
+      :sfx_target_name => "GALEGROUP_GREENR",
+      :coverage_begin_date => Date.new(1983,1,1),
+      :coverage_end_date => Date.new(2005,12,31)
+    }
+  ]
+
+end

--- a/test/unit/sfx/sfx_target_precedence_test.rb
+++ b/test/unit/sfx/sfx_target_precedence_test.rb
@@ -2,29 +2,29 @@ require 'test_helper'
 ### 
 ### Tests adding the followig config values to the SFX service adaptor
 ###
-### @preferred_targets - float specific targets to the top of full-text options
+### @boosted_targets - float specific targets to the top of full-text options
 ### @sunk_targets - sink specified targets to the bottom of full-text options
 
 class SfxTargetPrecedenceTest < ActiveSupport::TestCase
 
-  def test_preferred_target_appears_first
+  def test_boosted_target_appears_first
     sfx = Sfx.new({'priority' => 1, 
                    'base_url' => "http://example.org",
-                   'preferred_targets' => ['HIGHWIRE_PRESS_JOURNALS']
+                   'boosted_targets' => ['HIGHWIRE_PRESS_JOURNALS']
     })
-    new_list = sfx.sort_preferred_responses(@@svc_list_example)
+    new_list = sfx.sort_boosted_responses(@@svc_list_example)
     assert_not_same @@svc_list_example, new_list
     assert_equal @@svc_list_example.length, new_list.length
       
     assert_equal new_list.first[:sfx_target_name], 'HIGHWIRE_PRESS_JOURNALS'
   end
 
-  def test_preferred_wildcard
+  def test_boosted_wildcard
     sfx = Sfx.new({'priority' => 1, 
                    'base_url' => "http://example.org",
-                   'preferred_targets' => ['GALEGROUP_*']
+                   'boosted_targets' => ['GALEGROUP_*']
     })
-    new_list = sfx.sort_preferred_responses(@@svc_list_example)
+    new_list = sfx.sort_boosted_responses(@@svc_list_example)
     assert_not_same @@svc_list_example, new_list
       
     assert_equal new_list.first[:sfx_target_name], 'GALEGROUP_GREENR'
@@ -57,12 +57,12 @@ class SfxTargetPrecedenceTest < ActiveSupport::TestCase
     assert_equal new_list.last[:sfx_target_name], 'PROQUEST_MEDLINE_WITH_FULLTEXT'
   end
 
-  def test_preferred_targets_appear_in_order
+  def test_boosted_targets_appear_in_order
     sfx = Sfx.new({'priority' => 1, 
                    'base_url' => "http://example.org",
-                   'preferred_targets' => ['PROQUEST_CENTRAL_NEW_PLATFORM', 'HIGHWIRE_PRESS_JOURNALS']
+                   'boosted_targets' => ['PROQUEST_CENTRAL_NEW_PLATFORM', 'HIGHWIRE_PRESS_JOURNALS']
     })
-    new_list = sfx.sort_preferred_responses(@@svc_list_example)
+    new_list = sfx.sort_boosted_responses(@@svc_list_example)
     assert_not_same @@svc_list_example, new_list
     first_target = new_list[0]
     second_target = new_list[1]

--- a/test/unit/sfx/sfx_target_precedence_test.rb
+++ b/test/unit/sfx/sfx_target_precedence_test.rb
@@ -14,8 +14,21 @@ class SfxTargetPrecedenceTest < ActiveSupport::TestCase
     })
     new_list = sfx.sort_preferred_responses(@@svc_list_example)
     assert_not_same @@svc_list_example, new_list
+    assert_equal @@svc_list_example.length, new_list.length
       
     assert_equal new_list.first[:sfx_target_name], 'HIGHWIRE_PRESS_JOURNALS'
+  end
+
+  def test_preferred_wildcard
+    sfx = Sfx.new({'priority' => 1, 
+                   'base_url' => "http://example.org",
+                   'preferred_targets' => ['GALEGROUP_*']
+    })
+    new_list = sfx.sort_preferred_responses(@@svc_list_example)
+    assert_not_same @@svc_list_example, new_list
+      
+    assert_equal new_list.first[:sfx_target_name], 'GALEGROUP_GREENR'
+    assert_equal new_list.second[:sfx_target_name], 'GALEGROUP_BIOGRAPHY_IN_CONTEXT'
   end
 
   def test_sunk_target_appears_last
@@ -26,7 +39,22 @@ class SfxTargetPrecedenceTest < ActiveSupport::TestCase
     
     new_list = sfx.sort_sunk_responses(@@svc_list_example)
     assert_not_same @@svc_list_example, new_list
+    assert_equal @@svc_list_example.length, new_list.length
+
     assert_equal new_list.last[:sfx_target_name], 'JSTOR_EARLY_JOURNAL_CONTENT_FREE'
+  end
+
+  def test_sunk_wildcard
+    sfx = Sfx.new({'priority' => 1, 
+                   'base_url' => "http://example.org",
+                   'sunk_targets' => ['PROQUEST_*']
+    })
+    
+    new_list = sfx.sort_sunk_responses(@@svc_list_example)
+    assert_not_same @@svc_list_example, new_list
+    assert_equal @@svc_list_example.length, new_list.length
+
+    assert_equal new_list.last[:sfx_target_name], 'PROQUEST_MEDLINE_WITH_FULLTEXT'
   end
 
   def test_preferred_targets_appear_in_order
@@ -113,7 +141,7 @@ class SfxTargetPrecedenceTest < ActiveSupport::TestCase
       :coverage_end_date => Date.new(2005,12,31)
     },
     { :display_text => "GALEGROUP_BIOGRAPHY_IN_CONTEXT",
-      :sfx_target_name => "GALEGROUP_GREENR",
+      :sfx_target_name => "GALEGROUP_BIOGRAPHY_IN_CONTEXT",
       :coverage_begin_date => Date.new(1983,1,1),
       :coverage_end_date => Date.new(2005,12,31)
     }


### PR DESCRIPTION
Add feature to either prefer or sink SFX full-text targets based on values configured in umlaut_services.yml under @preferred_targets or @sunk_targets. Currently supports on full target strings, so PROQUEST_NEW_AWESOME_PLATFORM works but PROQUEST_ does not. These rules fire after any configured target roll ups. 