### PR TITLE
Pubmed is moving everything to https.

### DIFF
--- a/app/service_adaptors/pubmed.rb
+++ b/app/service_adaptors/pubmed.rb
@@ -10,7 +10,7 @@ class Pubmed < Service
   
   def initialize(config)
     @display_name = "PubMed"
-    @url = 'http://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi'
+    @url = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi'
     super(config)
   end
   


### PR DESCRIPTION
[See their announcement for more details](https://www.ncbi.nlm.nih.gov/home/bulletins/https-tests.shtml)

Net::HTTP doesn't auto-follow redirects, so checking pubmed will fail.

```
[1] pry(main)> url = 'http://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml&rettype=full&id=11958783'
=> "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml&rettype=full&id=11958783"
[2] pry(main)> response = Net::HTTP.get_response(URI.parse(url))
=> #<Net::HTTPMovedPermanently 301 Moved Permanently readbody=true>
[3] pry(main)> url = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&retmode=xml&rettype=full&id=11958783'
[4] pry(main)> response = Net::HTTP.get_response(URI.parse(url))
=> #<Net::HTTPOK 200 OK readbody=true>
```
